### PR TITLE
Fix crash when remeshing non-manifold meshes

### DIFF
--- a/src/AutoRemesher/autoremesher.cpp
+++ b/src/AutoRemesher/autoremesher.cpp
@@ -508,32 +508,46 @@ bool AutoRemesher::remesh()
                 thread.parameterizer->setScaling(thread.island->scaling);
                 thread.parameterizer->setGradientAdaptivity(thread.island->adaptivity);
                 thread.parameterizer->setSharpEdgeDegrees(thread.island->sharpEdgeDegrees);
-                {
+                bool parameterizeSucceeded = true;
+                try {
                     GeogramProgressLockGuard lock;
                     thread.parameterizer->parameterize();
+                } catch (const std::exception& e) {
+                    // Geogram reports failed assertions by throwing (e.g. the
+                    // manifold checks in quad_cover). One pathological island must
+                    // not abort the whole remesh, so log it and skip its quads.
+                    parameterizeSucceeded = false;
+                    std::cerr << "Island " << (thread.islandIndex + 1)
+                              << ": parameterization failed (" << e.what()
+                              << "), skipping this island." << std::endl;
+                } catch (...) {
+                    parameterizeSucceeded = false;
+                    std::cerr << "Island " << (thread.islandIndex + 1)
+                              << ": parameterization failed (unknown error), skipping this island." << std::endl;
                 }
 
                 auto t1 = std::chrono::high_resolution_clock::now();
                 *m_parameterizeTime += std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
 
-                thread.autoRemesher->setCurrentStatus(
-                    "Island " + std::to_string(thread.islandIndex + 1) + ": extracting quads...");
-                thread.autoRemesher->updateProgress(thread.islandIndex, 0.9f);
-                std::vector<std::vector<Vector2>>* uvs = thread.parameterizer->takeTriangleUvs();
-                thread.remesher = new QuadExtractor(&vertices,
-                    &triangles,
-                    uvs);
-                if (!thread.remesher->extract()) {
-                    delete thread.remesher;
-                    thread.remesher = nullptr;
+                if (parameterizeSucceeded) {
+                    thread.autoRemesher->setCurrentStatus(
+                        "Island " + std::to_string(thread.islandIndex + 1) + ": extracting quads...");
+                    thread.autoRemesher->updateProgress(thread.islandIndex, 0.9f);
+                    std::vector<std::vector<Vector2>>* uvs = thread.parameterizer->takeTriangleUvs();
+                    thread.remesher = new QuadExtractor(&vertices,
+                        &triangles,
+                        uvs);
+                    if (!thread.remesher->extract()) {
+                        delete thread.remesher;
+                        thread.remesher = nullptr;
+                    }
+                    delete uvs;
                 }
                 thread.autoRemesher->updateProgress(thread.islandIndex, 1.0f);
                 thread.autoRemesher->setCurrentStatus(
                     "Island " + std::to_string(thread.islandIndex + 1) + ": done");
                 auto t2 = std::chrono::high_resolution_clock::now();
                 *m_extractTime += std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
-
-                delete uvs;
             }
         }
 

--- a/src/AutoRemesher/parameterizer.cpp
+++ b/src/AutoRemesher/parameterizer.cpp
@@ -197,9 +197,14 @@ bool Parameterizer::parameterize()
             GEO::index_t c2 = M.facets.corners_begin(f2) + e2;
             GEO::index_t c3 = M.facets.next_corner_around_facet(f2, c2);
             if (M.facet_corners.vertex(c) != M.facet_corners.vertex(c3)) {
+                // Inconsistently-oriented (non-manifold) edge: break it on BOTH
+                // sides. c2 is the reciprocal corner -- find_adjacent guarantees
+                // its adjacent_facet is f1 -- so c2 (not a neighbour of it) is the
+                // corner that must also be cleared. Clearing the wrong corner
+                // leaves c2 -> f1 dangling and trips geogram's quad_cover
+                // adjacency assertion (quad_cover.cpp:204) on non-manifold meshes.
                 M.facet_corners.set_adjacent_facet(c, GEO::NO_FACET);
-                GEO::index_t cRecip = M.facets.prev_corner_around_facet(f2, c2);
-                M.facet_corners.set_adjacent_facet(cRecip, GEO::NO_FACET);
+                M.facet_corners.set_adjacent_facet(c2, GEO::NO_FACET);
             }
         }
     };


### PR DESCRIPTION
QuadCover aborted with a geo_assert (facet-corner adjacency) on non-manifold input such as an inconsistently-oriented edge. Geogram raises failed assertions as exceptions, so the uncaught throw reached terminate() and crashed the program.

- parameterizer.cpp: when breaking an inconsistently-oriented edge in makeMesh, clear the true reciprocal corner c2 (the corner find_adjacent reports as pointing back to f1) instead of prev(c2), so the edge is unlinked on both sides and quad_cover's adjacency invariant holds.
- autoremesher.cpp: wrap each island's parameterize() in try/catch so a geogram assertion on one pathological island is logged and skipped rather than aborting the whole remesh (also avoids handing a null UV buffer to the quad extractor).