### PR TITLE
Added compile fix from #42

### DIFF
--- a/thirdparty/isotropicremesher/isotropichalfedgemesh.h
+++ b/thirdparty/isotropicremesher/isotropichalfedgemesh.h
@@ -24,6 +24,7 @@
 #include <set>
 #include <functional>
 #include "vector3.h"
+#include <cstdint>
 
 class IsotropicHalfedgeMesh
 {


### PR DESCRIPTION
Hi, I just added the simple changes to make it compile in Artix/Arch, by simply adding ```<cstdint>``` to ```thirdparty/isotropicremesher/isotropichalfedgemesh.h``` 