### PR TITLE
Enable high DPI scaling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,11 @@ int main(int argc, char** argv)
     QCoreApplication::setOrganizationName(APP_COMPANY);
     QCoreApplication::setOrganizationDomain(APP_HOMEPAGE_URL);
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+
     QCommandLineParser parser;
     parser.setApplicationDescription("AutoRemesher - Automatic quad remeshing tool");
     parser.addHelpOption();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,16 +73,17 @@ static HeadlessParams parseHeadlessArgs(QCommandLineParser& parser)
 
 int main(int argc, char** argv)
 {
-    QApplication app(argc, argv);
-
-    QCoreApplication::setApplicationName(APP_NAME);
-    QCoreApplication::setOrganizationName(APP_COMPANY);
-    QCoreApplication::setOrganizationDomain(APP_HOMEPAGE_URL);
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
+
+    QApplication app(argc, argv);
+
+    QCoreApplication::setApplicationName(APP_NAME);
+    QCoreApplication::setOrganizationName(APP_COMPANY);
+    QCoreApplication::setOrganizationDomain(APP_HOMEPAGE_URL);
 
     QCommandLineParser parser;
     parser.setApplicationDescription("AutoRemesher - Automatic quad remeshing tool");


### PR DESCRIPTION
Same as https://github.com/huxingyi/dust3d/pull/194

Qt 5 high-DPI scaling is enabled via `Qt::AA_EnableHighDpiScaling` to respect the platform display scale.

Closes #40